### PR TITLE
Fixes #9 - PopulateAsync fails when more than 1k IndexOperations

### DIFF
--- a/src/RedDog.Search.Tests/Extensions/ListExtensionsTest.cs
+++ b/src/RedDog.Search.Tests/Extensions/ListExtensionsTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace RedDog.Search.Tests
+{
+    [TestClass]
+    public class ListExtensionsTest
+    {
+        [TestMethod]
+        public void ChunkTest()
+        {
+            List<int> list = CreateList(999);
+            List<List<int>> chunked = list.Chunk(1000);
+            Assert.IsNotNull(chunked);
+            Assert.IsTrue(chunked.Count == 1);
+            Assert.IsTrue(chunked[0].Count == 999);
+
+
+            list = CreateList(1000);
+            chunked = list.Chunk(1000);
+            Assert.IsNotNull(chunked);
+            Assert.IsTrue(chunked.Count == 1);
+            Assert.IsTrue(chunked[0].Count == 1000);
+
+            list = CreateList(1001);
+            chunked = list.Chunk(1000);
+            Assert.IsNotNull(chunked);
+            Assert.IsTrue(chunked.Count == 2);
+            Assert.IsTrue(chunked[0].Count == 1000);
+            Assert.IsTrue(chunked[1].Count == 1);
+        }
+
+        private List<int> CreateList(int elementCount)
+        {
+            if (elementCount <= 0) { return new List<int>(); }
+            List<int> result = new List<int>();
+            for (int i = 0; i < elementCount; i++)
+            {
+                result.Add(i);
+            }
+            return result;
+        }
+    }
+}

--- a/src/RedDog.Search.Tests/Properties/AssemblyInfo.cs
+++ b/src/RedDog.Search.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitleAttribute("RedDog.Search.Tests")]
+[assembly: AssemblyDescriptionAttribute("UnitTest Suit for RedDog.Search")]
+[assembly: AssemblyProductAttribute("Red Dog")]
+[assembly: AssemblyVersionAttribute("0.5.1.0")]
+[assembly: AssemblyFileVersionAttribute("0.5.1.0")]
+namespace System
+{
+    internal static class AssemblyVersionInformation
+    {
+        internal const string Version = "0.5.1.0";
+    }
+}

--- a/src/RedDog.Search.Tests/RedDog.Search.Tests.csproj
+++ b/src/RedDog.Search.Tests/RedDog.Search.Tests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C5503BB5-66C9-4E32-88C2-46E448022018}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RedDog.Search.Tests</RootNamespace>
+    <AssemblyName>RedDog.Search.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="Extensions\ListExtensionsTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RedDog.Search\RedDog.Search.csproj">
+      <Project>{f3cdc9c8-a12f-429c-a9da-fb57a9619ccd}</Project>
+      <Name>RedDog.Search</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/RedDog.Search.sln
+++ b/src/RedDog.Search.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedDog.Search", "RedDog.Search\RedDog.Search.csproj", "{F3CDC9C8-A12F-429C-A9DA-FB57A9619CCD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedDog.Search.Tests", "RedDog.Search.Tests\RedDog.Search.Tests.csproj", "{C5503BB5-66C9-4E32-88C2-46E448022018}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{F3CDC9C8-A12F-429C-A9DA-FB57A9619CCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3CDC9C8-A12F-429C-A9DA-FB57A9619CCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3CDC9C8-A12F-429C-A9DA-FB57A9619CCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5503BB5-66C9-4E32-88C2-46E448022018}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5503BB5-66C9-4E32-88C2-46E448022018}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5503BB5-66C9-4E32-88C2-46E448022018}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5503BB5-66C9-4E32-88C2-46E448022018}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RedDog.Search/Constants.cs
+++ b/src/RedDog.Search/Constants.cs
@@ -1,0 +1,15 @@
+﻿
+namespace RedDog.Search
+{
+    /// <summary>
+    /// RedDog.Search constants
+    /// </summary>
+    internal static class Constants
+    {
+        // http://msdn.microsoft.com/en-us/library/azure/dn798930.aspx
+        /// <summary>
+        /// Maximum number of documents per batch
+        /// </summary>
+        public const int MaxDocumentPerBatch = 1000;
+    }
+}

--- a/src/RedDog.Search/Extensions/ListExtensions.cs
+++ b/src/RedDog.Search/Extensions/ListExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RedDog.Search
+{
+    /// <summary>
+    /// Provides extensions methods for the <see cref="List{T}"/> generic type.
+    /// </summary>
+    public static class ListExtensions
+    {
+        /// <summary>
+        /// Chunk a list into a number of parts
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public static List<List<T>> Chunk<T>(this List<T> source, int num)
+        {
+            if (num <= 0)
+            {
+                throw new ArgumentException("num should be positive", "num");
+            }
+
+            return source
+                .Select((x, i) => new { Index = i, Value = x })
+                .GroupBy(x => x.Index / num)
+                .Select(x => x.Select(y => y.Value).ToList())
+                .ToList();
+        }
+    }
+}

--- a/src/RedDog.Search/RedDog.Search.csproj
+++ b/src/RedDog.Search/RedDog.Search.csproj
@@ -45,6 +45,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Constants.cs" />
+    <Compile Include="Extensions\ListExtensions.cs" />
     <Compile Include="Http\ApiConnection.cs" />
     <Compile Include="Http\ApiConstants.cs" />
     <Compile Include="Http\ApiRequestExtensions.cs" />


### PR DESCRIPTION
Fixes #9
- Added PopulateBatchAsync method to IndexManagementClient class.
  This method splits the IndexOperation param array into parts matching the REST API batch limit.
- Added unit test for the List<T>.Chunk() extension method.
